### PR TITLE
Add maintenance profiles and general improvements

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -64,6 +64,19 @@ instances:
         key: alter
         value: "true"
         remove: false
+profiles:
+  count:
+    operational:
+      check: transition
+      trigger: alter
+    maintenance-required:
+      check: transition && transition
+    in-maintenance:
+      check: transition && transition && transition
+  test:
+    operational:
+      check: transition
+      trigger: alter
 
 `
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -117,9 +118,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&NodeReconciler{
-		Client: k8sManager.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("maintenance"),
-		Scheme: k8sManager.GetScheme(),
+		Client:   k8sManager.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("maintenance"),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: record.NewFakeRecorder(1024),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/main.go
+++ b/main.go
@@ -90,9 +90,10 @@ func main() {
 	}
 
 	if err = (&controllers.NodeReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("Node"),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Log:      ctrl.Log.WithName("controllers").WithName("Node"),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("maintenance-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Node")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -24,10 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -76,13 +73,6 @@ func main() {
 		Port:               9443, //nolint:gomnd
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "6a2f7a03.my.domain",
-		// use a client without caching this garantuess that a very recent version of the node is reconciled
-		// by changing labels the controller can trigger it's own executions
-		// accessing an outdated cache during such a triggered executions can lead to doubled notifications
-		// as old state information is processed again
-		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
-			return client.New(restConfig, options)
-		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/main.go
+++ b/main.go
@@ -24,7 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -73,6 +76,13 @@ func main() {
 		Port:               9443, //nolint:gomnd
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "6a2f7a03.my.domain",
+		// use a client without caching this garantuess that a very recent version of the node is reconciled
+		// by changing labels the controller can trigger it's own executions
+		// accessing an outdated cache during such a triggered executions can lead to doubled notifications
+		// as old state information is processed again
+		NewClient: func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
+			return client.New(restConfig, options)
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/plugin/notification.go
+++ b/plugin/notification.go
@@ -57,6 +57,9 @@ func (chain *NotificationChain) Execute(params Parameters) error {
 				Err:     err,
 			}
 		}
+		if params.Log != nil {
+			params.Log.Info("Executed notification instance", "instance", notifier.Name)
+		}
 	}
 	return nil
 }

--- a/plugin/trigger.go
+++ b/plugin/trigger.go
@@ -55,6 +55,9 @@ func (chain *TriggerChain) Execute(params Parameters) error {
 				Err:     err,
 			}
 		}
+		if params.Log != nil {
+			params.Log.Info("Executed trigger instance", "instance", trigger.Name)
+		}
 	}
 	return nil
 }

--- a/state/operational.go
+++ b/state/operational.go
@@ -41,7 +41,16 @@ func (s *operational) Label() NodeStateLabel {
 }
 
 func (s *operational) Notify(params plugin.Parameters, data *Data) error {
-	return notifyDefault(params, data, s.interval, &s.chains.Notification, s.label)
+	if data.LastNotificationState == Operational {
+		return nil
+	}
+	err := s.chains.Notification.Execute(params)
+	if err != nil {
+		return err
+	}
+	data.LastNotification = time.Now()
+	data.LastNotificationState = Operational
+	return nil
 }
 
 func (s *operational) Trigger(params plugin.Parameters, data *Data) error {

--- a/state/operational_test.go
+++ b/state/operational_test.go
@@ -109,4 +109,34 @@ var _ = Describe("Operational State", func() {
 
 	})
 
+	It("should execute the notification chain if the state has changed", func() {
+		chain, notification := mockNotificationChain()
+		data := Data{
+			LastTransition:        time.Now(),
+			LastNotification:      time.Now(),
+			LastNotificationState: InMaintenance,
+		}
+		oper := operational{
+			chains: PluginChains{Notification: chain},
+		}
+		err := oper.Notify(plugin.Parameters{}, &data)
+		Expect(err).To(Succeed())
+		Expect(notification.Invoked).To(Equal(1))
+	})
+
+	It("should not execute the notification chain if the state has not changed", func() {
+		chain, notification := mockNotificationChain()
+		data := Data{
+			LastTransition:        time.Now(),
+			LastNotification:      time.Now(),
+			LastNotificationState: Operational,
+		}
+		oper := operational{
+			chains: PluginChains{Notification: chain},
+		}
+		err := oper.Notify(plugin.Parameters{}, &data)
+		Expect(err).To(Succeed())
+		Expect(notification.Invoked).To(Equal(0))
+	})
+
 })

--- a/state/state.go
+++ b/state/state.go
@@ -45,6 +45,11 @@ type PluginChains struct {
 	Trigger      plugin.TriggerChain
 }
 
+type Profile struct {
+	Name   string
+	Chains map[NodeStateLabel]PluginChains
+}
+
 // Data represents global state which is saved with a node annotation.
 type Data struct {
 	LastTransition        time.Time

--- a/state/state.go
+++ b/state/state.go
@@ -33,7 +33,7 @@ type NodeStateLabel string
 const Operational NodeStateLabel = "operational"
 
 // Required is a label that marks a node which needs to be maintenaned.
-const Required NodeStateLabel = "required"
+const Required NodeStateLabel = "maintenance-required"
 
 // InMaintenance is a label that marks a node which is currently in maintenance.
 const InMaintenance NodeStateLabel = "in-maintenance"


### PR DESCRIPTION
Maintenance profiles simplify the configuration by defining plugin chains in the configuration file instead of node annotations. Fixed the double notification bug and improved logging.