### PR TITLE
fix new lints

### DIFF
--- a/common/schedule.go
+++ b/common/schedule.go
@@ -269,7 +269,7 @@ func waitForPodDeletion(ctx context.Context, k8sClient client.Client, pod corev1
 	return wait.PollImmediate(params.Period, params.Timeout, func() (bool, error) { //nolint:staticcheck
 		var p corev1.Pod
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, &p)
-		if errors.IsNotFound(err) || (p.ObjectMeta.UID != pod.ObjectMeta.UID) {
+		if errors.IsNotFound(err) || (p.ObjectMeta.UID != pod.ObjectMeta.UID) { //nolint:staticcheck // "ObjectMeta" is an embedded field and could be omitted, but it would make the line less readable
 			return true, nil
 		} else if err != nil {
 			return false, err

--- a/esx/runnable.go
+++ b/esx/runnable.go
@@ -91,7 +91,7 @@ func (r *Runnable) Reconcile(ctx context.Context) {
 		return
 	}
 	var nodes v1.NodeList
-	err = r.Client.List(ctx, &nodes, client.HasLabels{constants.HostLabelKey, constants.FailureDomainLabelKey})
+	err = r.List(ctx, &nodes, client.HasLabels{constants.HostLabelKey, constants.FailureDomainLabelKey})
 	if err != nil {
 		r.Log.Error(err, "Failed to retrieve list of cluster nodes.")
 		return

--- a/event/event.go
+++ b/event/event.go
@@ -86,10 +86,7 @@ func recordToSink(sink record.EventSink, event *v1.Event,
 		return
 	}
 	tries := 0
-	for {
-		if recordEvent(sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
-			break
-		}
+	for !recordEvent(sink, result.Event, result.Patch, result.Event.Count > 1, eventCorrelator) {
 		tries++
 		if tries >= maxTriesPerEvent {
 			klog.Errorf("Unable to write event '%#v' (retry limit exceeded!)", event)


### PR DESCRIPTION
The new staticcheck version added some quickfix suggestions.

FWIW, I'm on edge about the "r.Client.List -> r.List" replacement. In vpa_butler, there are significantly more replacements like this, so I would like to hear Erik's opinion before continuing there. If this replacement is not desired, it's probably best to disable QF1008 for these repos.