### PR TITLE
Fix RetryError not matched through ChainError wrapping

### DIFF
--- a/controllers/node_handler.go
+++ b/controllers/node_handler.go
@@ -83,7 +83,7 @@ func ApplyProfiles(ctx context.Context, params reconcileParameters, data *state.
 		if err == nil {
 			continue
 		}
-		if errors.Is(err, retryErr) {
+		if errors.As(err, &retryErr) {
 			profilesWithRetryError[ps.Profile.Name] = struct{}{}
 		} else {
 			errs = append(errs, err)

--- a/plugin/impl/eviction.go
+++ b/plugin/impl/eviction.go
@@ -94,7 +94,8 @@ func (e *Eviction) Trigger(params plugin.Parameters) error {
 			ForceEviction: e.ForceEviction,
 		})
 		if err != nil {
-			return err
+			params.Log.Error(err, "Drain encountered errors; will retry next reconcile", "node", params.Node.Name)
+			return &plugin.RetryError{Message: err.Error()}
 		}
 		if !drained {
 			params.Log.Info("Drain still in progress; will continue in next reconcile", "node", params.Node.Name)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -18,7 +18,7 @@ func TestPlugins(t *testing.T) {
 	RunSpecs(t, "Plugin Suite")
 }
 
-var _ = Describe("CheckError", func() {
+var _ = Describe("ChainError", func() {
 	chainErr := ChainError{
 		Message: "msg",
 		Err:     errors.New("err"),
@@ -32,6 +32,25 @@ var _ = Describe("CheckError", func() {
 	It("should unwrap the root error", func() {
 		err := chainErr.Unwrap()
 		Expect(err.Error()).To(Equal("err"))
+	})
+})
+
+var _ = Describe("RetryError", func() {
+	It("is extractable via errors.As through ChainError wrapping", func() {
+		retryErr := &RetryError{Message: "drain still in progress"}
+		wrapped := &ChainError{Message: "trigger chain failed", Err: retryErr}
+
+		var extracted *RetryError
+		Expect(errors.As(wrapped, &extracted)).To(BeTrue())
+		Expect(extracted.Message).To(Equal("drain still in progress"))
+	})
+
+	It("is not matched by errors.Is with a different instance", func() {
+		retryErr := &RetryError{Message: "some error"}
+		wrapped := &ChainError{Message: "trigger chain failed", Err: retryErr}
+
+		// errors.Is uses pointer identity for types without Is() method
+		Expect(errors.Is(wrapped, &RetryError{})).To(BeFalse())
 	})
 })
 

--- a/state/state.go
+++ b/state/state.go
@@ -192,7 +192,8 @@ func Apply(state NodeState, node *v1.Node, data *Data, params plugin.Parameters)
 	}
 	if stateInfo.Previous != stateInfo.Current {
 		err := state.Enter(params, data)
-		if errors.Is(err, &plugin.RetryError{}) {
+		var retryErr *plugin.RetryError
+		if errors.As(err, &retryErr) {
 			return result, err
 		}
 		if err != nil {


### PR DESCRIPTION
## Summary

- Use `errors.As` instead of `errors.Is` when checking for `*plugin.RetryError` in `state.Apply()` and `controllers.ApplyProfiles()`. `errors.Is` with pointer types uses `==` comparison, which never matches different instances of the same type through an error chain.
- Change the eviction plugin to return `RetryError` for drain failures instead of hard errors. Hard errors abort the reconcile and skip the node patch, preventing cordon from taking effect on the API server.

## Root cause

When a trigger plugin (e.g. eviction/drain) encounters a PDB violation, it returned a hard error wrapped in `ChainError`. The callers tried `errors.Is(err, &plugin.RetryError{})` which always returned false (pointer identity), causing the error to be treated as fatal. This aborted the reconcile loop before the node patch, so cordon was never applied — pods got rescheduled back, creating an infinite eviction loop.

## Test plan

- [x] Added unit tests verifying `errors.As` extracts `RetryError` through `ChainError`
- [x] Added unit test confirming `errors.Is` does NOT match (documenting the pitfall)
- [x] All existing state, plugin, and plugin/impl tests pass
- [x] Controller and ESX integration tests pass (via `gmake build/cover.out`)