### PR TITLE
Added request trigger in plugins

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -194,6 +194,7 @@ func addPluginsToRegistry(registry *plugin.Registry) {
 		&impl.AlterHypervisor{},
 		&impl.AlterLabel{},
 		&impl.Eviction{},
+		&impl.Request{},
 	}
 	for _, trigger := range triggers {
 		registry.TriggerPlugins[trigger.ID()] = trigger

--- a/plugin/impl/request.go
+++ b/plugin/impl/request.go
@@ -2,13 +2,10 @@ package impl
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -19,23 +16,17 @@ import (
 
 // Request is a trigger plugin that sends an HTTP request to a configured endpoint.
 type Request struct {
-	URL      string
-	Method   string
-	Body     string
-	CertFile string
-	KeyFile  string
-	CAFile   string
+	URL    string
+	Method string
+	Body   string
 }
 
 // New creates a new Request instance with the given config.
 func (r *Request) New(config *ucfgwrap.Config) (plugin.Trigger, error) {
 	conf := struct {
-		URL      string `config:"url" validate:"required"`
-		Method   string `config:"method"`
-		Body     string `config:"body"`
-		CertFile string `config:"certFile"`
-		KeyFile  string `config:"keyFile"`
-		CAFile   string `config:"caFile"`
+		URL    string `config:"url" validate:"required"`
+		Method string `config:"method"`
+		Body   string `config:"body"`
 	}{
 		Method: "POST", // Default to POST for backward compatibility
 	}
@@ -43,12 +34,9 @@ func (r *Request) New(config *ucfgwrap.Config) (plugin.Trigger, error) {
 		return nil, err
 	}
 	return &Request{
-		URL:      conf.URL,
-		Method:   conf.Method,
-		Body:     conf.Body,
-		CertFile: conf.CertFile,
-		KeyFile:  conf.KeyFile,
-		CAFile:   conf.CAFile,
+		URL:    conf.URL,
+		Method: conf.Method,
+		Body:   conf.Body,
 	}, nil
 }
 
@@ -65,17 +53,7 @@ func (r *Request) Trigger(params plugin.Parameters) error {
 	// Replace placeholders in body
 	body := r.replacePlaceholders(r.Body, params)
 
-	// Create HTTP client with TLS if certificates provided
 	client := &http.Client{Timeout: 30 * time.Second}
-	if r.CertFile != "" && r.KeyFile != "" {
-		tlsConfig, err := r.createTLSConfig()
-		if err != nil {
-			return fmt.Errorf("failed to create TLS config: %w", err)
-		}
-		client.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-		}
-	}
 
 	// Create request
 	var req *http.Request
@@ -141,32 +119,6 @@ func (r *Request) replacePlaceholders(s string, params plugin.Parameters) string
 	}
 	
 	return s
-}
-
-// createTLSConfig creates a TLS configuration with client certificates.
-func (r *Request) createTLSConfig() (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(r.CertFile, r.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load client certificate: %w", err)
-	}
-
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-	}
-
-	if r.CAFile != "" {
-		caCert, err := os.ReadFile(r.CAFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
-		}
-		caCertPool := x509.NewCertPool()
-		if !caCertPool.AppendCertsFromPEM(caCert) {
-			return nil, fmt.Errorf("failed to parse CA certificate")
-		}
-		tlsConfig.RootCAs = caCertPool
-	}
-
-	return tlsConfig, nil
 }
 
 // extractAndStoreSilenceID extracts the silence ID from AlertManager response and stores it as a node label.

--- a/plugin/impl/request.go
+++ b/plugin/impl/request.go
@@ -1,0 +1,202 @@
+package impl
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sapcc/ucfgwrap"
+
+	"github.com/sapcc/maintenance-controller/plugin"
+)
+
+// Request is a trigger plugin that sends an HTTP request to a configured endpoint.
+type Request struct {
+	URL      string
+	Method   string
+	Body     string
+	CertFile string
+	KeyFile  string
+	CAFile   string
+}
+
+// New creates a new Request instance with the given config.
+func (r *Request) New(config *ucfgwrap.Config) (plugin.Trigger, error) {
+	conf := struct {
+		URL      string `config:"url" validate:"required"`
+		Method   string `config:"method"`
+		Body     string `config:"body"`
+		CertFile string `config:"certFile"`
+		KeyFile  string `config:"keyFile"`
+		CAFile   string `config:"caFile"`
+	}{
+		Method: "POST", // Default to POST for backward compatibility
+	}
+	if err := config.Unpack(&conf); err != nil {
+		return nil, err
+	}
+	return &Request{
+		URL:      conf.URL,
+		Method:   conf.Method,
+		Body:     conf.Body,
+		CertFile: conf.CertFile,
+		KeyFile:  conf.KeyFile,
+		CAFile:   conf.CAFile,
+	}, nil
+}
+
+func (r *Request) ID() string {
+	return "request"
+}
+
+// Trigger sends an HTTP request to the configured URL.
+// Supports placeholders: {{nodeName}}, {{state}}, {{startsAt}}, {{endsAt}}, {{silenceId}}.
+func (r *Request) Trigger(params plugin.Parameters) error {
+	// Replace placeholders in URL
+	url := r.replacePlaceholders(r.URL, params)
+	
+	// Replace placeholders in body
+	body := r.replacePlaceholders(r.Body, params)
+
+	// Create HTTP client with TLS if certificates provided
+	client := &http.Client{Timeout: 30 * time.Second}
+	if r.CertFile != "" && r.KeyFile != "" {
+		tlsConfig, err := r.createTLSConfig()
+		if err != nil {
+			return fmt.Errorf("failed to create TLS config: %w", err)
+		}
+		client.Transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+		}
+	}
+
+	// Create request
+	var req *http.Request
+	var err error
+	if r.Body != "" {
+		req, err = http.NewRequest(r.Method, url, strings.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, err = http.NewRequest(r.Method, url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+	}
+
+	// Send request
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s failed: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("request to %s returned status %d: %s", url, resp.StatusCode, string(respBody))
+	}
+
+	params.Log.Info("Request trigger executed", "url", url, "method", r.Method, "status", resp.StatusCode)
+	
+	// For POST requests to AlertManager, extract and store silence ID
+	if r.Method == "POST" && strings.Contains(url, "/silences") {
+		if err := r.extractAndStoreSilenceID(respBody, params); err != nil {
+			params.Log.Error(err, "Failed to extract silence ID")
+			// Don't fail the trigger, just log the error
+		}
+	}
+	
+	return nil
+}
+
+// replacePlaceholders replaces all placeholders in the given string.
+func (r *Request) replacePlaceholders(s string, params plugin.Parameters) string {
+	s = strings.ReplaceAll(s, "{{nodeName}}", params.Node.Name)
+	s = strings.ReplaceAll(s, "{{state}}", params.State)
+	
+	// Generate timestamps
+	now := time.Now().UTC()
+	startsAt := now.Format(time.RFC3339)
+	endsAt := now.Add(48 * time.Hour).Format(time.RFC3339) // 48 hour maintenance window
+	s = strings.ReplaceAll(s, "{{startsAt}}", startsAt)
+	s = strings.ReplaceAll(s, "{{endsAt}}", endsAt)
+	
+	// Get silence ID from node label if exists
+	if silenceID, ok := params.Node.Labels["cloud.sap/alertmanager-silence-id"]; ok {
+		s = strings.ReplaceAll(s, "{{silenceId}}", silenceID)
+	}
+	
+	return s
+}
+
+// createTLSConfig creates a TLS configuration with client certificates.
+func (r *Request) createTLSConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(r.CertFile, r.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+
+	if r.CAFile != "" {
+		caCert, err := os.ReadFile(r.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	return tlsConfig, nil
+}
+
+// extractAndStoreSilenceID extracts the silence ID from AlertManager response and stores it as a node label.
+func (r *Request) extractAndStoreSilenceID(respBody []byte, params plugin.Parameters) error {
+	var response struct {
+		SilenceID string `json:"silenceID"`
+	}
+	
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+	
+	if response.SilenceID == "" {
+		return fmt.Errorf("no silenceID in response")
+	}
+	
+	params.Log.Info("Storing silence ID in node label", "silenceID", response.SilenceID)
+	
+	// Store silence ID as a node label
+	node := params.Node.DeepCopy()
+	if node.Labels == nil {
+		node.Labels = make(map[string]string)
+	}
+	node.Labels["cloud.sap/alertmanager-silence-id"] = response.SilenceID
+	
+	ctx := context.Background()
+	err := params.Client.Update(ctx, node)
+	if err != nil {
+		return fmt.Errorf("failed to update node label with silence ID: %w", err)
+	}
+	
+	return nil
+}


### PR DESCRIPTION
## Add `request` trigger plugin

Adds a new `request` trigger plugin that sends HTTP requests during node state transitions. Primary use case: managing Alertmanager silences automatically when nodes enter/exit maintenance.

### Changes

| File                     | Change                              |
| ------------------------ | ----------------------------------- |
| `plugin/impl/request.go` | New `request` trigger plugin        |
| `controllers/config.go`  | Register plugin in trigger registry |

### Features

- Body placeholder substitution: `{{nodeName}}`, `{{state}}`, `{{startsAt}}`, `{{endsAt}}`, `{{silenceId}}`
- Extracts Alertmanager silence ID from POST response and stores it as node label `cloud.sap/alertmanager-silence-id`

### Example config

```yaml
    # Create AlertManager silence when entering maintenance
    - type: request
      name: create_alertmanager_silence
      config:
        url: "https://alertmanager-internal.scaleout.qa-de-1.cloud.sap/api/v2/silences"
        method: "POST"
        body: '{"matchers": [{"name": "node", "value": "{{ "{{" }}nodeName{{ "}}" }}", "isRegex": false}, {"name": "region", "value": "{{ "{{" }}.Values.global.region{{ "}}" }}", "isRegex": false}, {"name": "service", "value": "ceph", "isRegex": false}, {"name": "severity", "value": "warning|info", "isRegex": true}, {"name": "support_group", "value": "storage", "isRegex": false}], "startsAt": "{{ "{{" }}startsAt{{ "}}" }}", "endsAt": "{{ "{{" }}endsAt{{ "}}" }}", "createdBy": "maintenance-controller", "comment": "Node {{ "{{" }}nodeName{{ "}}" }} entering maintenance"}'
    # Delete AlertManager silence when exiting maintenance
    - type: request
      name: delete_alertmanager_silence
      config:
        url: "https://alertmanager-internal.scaleout.qa-de-1.cloud.sap/api/v2/silence/{{ "{{" }}silenceId{{ "}}" }}"
        method: "DELETE"
```

### QA validation (st1-qa-de-1)

- Node enters `in-maintenance` → silence created (HTTP 200), ID stored as label
- Node exits to `operational` → silence expired via DELETE (HTTP 200)
- [qa_test.log](https://github.com/user-attachments/files/29513705/qa_test.log)

### TODO

- [ ] Unit tests
- [ ] Documentation update in `docs/plugins.md`
- [x] Customize request body via Helm values for per-cluster configuration
- [x] Support group-level matchers for silencing alerts
